### PR TITLE
Fix broken search and respect protocol

### DIFF
--- a/templates/script.php
+++ b/templates/script.php
@@ -7,14 +7,14 @@
  * @license   https://github.com/tobiju/bookdown-bootswatch-templates/blob/master/LICENSE.txt New BSD License
  */
 ?>
-<script src="https://code.jquery.com/jquery-2.2.0.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"
+<script src="//code.jquery.com/jquery-2.2.0.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"
         integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS"
         crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/0.6.0/lunr.min.js"></script>
-<script src="http://bartaz.github.io/sandbox.js/jquery.highlight.js"></script>
-<script src="https://tobiju.github.io/share/prismjs/main.js"></script>
-<script src="https://tobiju.github.io/share/prismjs/prism.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/lunr.js/0.6.0/lunr.min.js"></script>
+<script src="//bartaz.github.io/sandbox.js/jquery.highlight.js"></script>
+<script src="//tobiju.github.io/share/prismjs/main.js"></script>
+<script src="//tobiju.github.io/share/prismjs/prism.js"></script>
 <script type="text/javascript">
 
     function Search() {


### PR DESCRIPTION
GitHub supports HTTPs now and the search is broken because of `http://bartaz.github.io/sandbox.js/jquery.highlight.js`. This will fix it. /cc @tobiju 